### PR TITLE
Fix a FTBFS when calling an absent header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_D
 
 target_sources(${PROJECT_NAME} PRIVATE
 	scene-as-transition.c
-	scene-as-transition.h
 	version.h)
 
 if(BUILD_OUT_OF_TREE)


### PR DESCRIPTION
This commit fixes a Fail To Build From Source caused by an invalid call to scene-as-transition.h, an empty file that was removed via a30b061. This change is related to a discussion in #8.